### PR TITLE
[Bug fix] Update __init__.py with the analysis module

### DIFF
--- a/skweak/__init__.py
+++ b/skweak/__init__.py
@@ -1,2 +1,2 @@
-from . import base, doclevel, gazetteers, heuristics, aggregation, utils, spacy
+from . import analysis, base, doclevel, gazetteers, heuristics, aggregation, utils, spacy
 __version__ = "0.2.18"


### PR DESCRIPTION
It seems someone forgot to add the new `analysis` module to `__init__.py`.  

Trying to `import skweak.analysis` or `from skweak.analysis import LFAnalysis` will trigger the error `ModuleNotFoundError: No module named 'skweak.analysis'`.

Here we fix this bug by including the `analysis` module on the `__init__.py` file.