### PR TITLE
Introduced RegexAnnotator and LabelMapper

### DIFF
--- a/skweak/gazetteers.py
+++ b/skweak/gazetteers.py
@@ -9,8 +9,6 @@ import gzip
 # Gazetteer annotator
 ############################################
 
-
-
 class GazetteerAnnotator(base.SpanAnnotator):
     """Annotation using a gazetteer, i.e. a large list of entity terms. The annotation can
     look at either case-sensitive and case-insensitive occurrences.  The annotator relies 

--- a/skweak/spacy.py
+++ b/skweak/spacy.py
@@ -170,16 +170,23 @@ class LabelMapper(SpanAnnotator):
         edits the span groups in place!"""
 
         for source in set(self.sources).intersection(doc.spans):
-
+            
             new_group = []
             for span in doc.spans[source]:
-                span.label_ = self.mapping.get(span.label_, span.label_)
+
+                if span.label_ in self.mapping:
+
+                    span = Span(
+                        doc,
+                        span.start,
+                        span.end,
+                        self.mapping.get(span.label_)
+                    )
 
                 if self.inplace:
                     new_group.append(span)
                 else:
                     yield span.start, span.end, span.label_
-                
-
+                    
             if self.inplace:
                 doc.spans[source] = new_group


### PR DESCRIPTION
This PR adds two classes, the RegexAnnotator (which does exactly what you think) and the LabelMapper which enables us to replace labels or groups of labels with another label, either inplace or as a new span group.

They can be used like this:
``` python

import spacy, re
from skweak import heuristics, utils
import skweak.spacy as skwacy

nlp = spacy.load("en_core_web_sm")
doc = nlp("is Donald Trump´s email angry_orange1954@gmail.com? call 004593928340 for more.")


# LF 1: detection of emails with a regex
lf1= heuristics.RegexAnnotator(
        "email_identifier",
        pattern=r"[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+[\.\w\d]+\.\w{2,}",
        tag="EMAIL"
)

# LF 1: detection of phone numbers with a regex
lf2= heuristics.RegexAnnotator(
        "phone_identifier",
        pattern=r"(?:(?:0{2,}|\+)\s?\d{2,3}\s?)?(?:\d{2}\s\d{2}\s\d{2}\s\d{2}|\d{4}\s?\d{4}|\d{7})",
        tag="PHONE",
)
doc = lf1(lf2(doc))
print(doc.spans)
# {'phone_identifier': [004593928340], 'email_identifier': [angry_orange1954@gmail.com]}

# LF 3: relabel spans
lf3=skwacy.LabelMapper(
        "personal_info_identifier",
        mapping={ ("EMAIL", "PHONE"): "PI"},
        sources=["email_identifier", "phone_identifier"],
        inplace=True,
)
doc = lf3(doc)

print(doc.spans["email_identifier"][0].label_, doc.spans["phone_identifier"][0].label_)
# PI, PI
```

The LabelMapper is primarily intended to aggregate labels when using pre-trained NER models, e.g. spacy md and lg models that support a wide array of labels such as `('DATE','EVENT', 'LANGUAGE','LAW','MONEY','ORDINAL','PERCENT','PRODUCT', 'QUANTITY', 'TIME', 'WORK_OF_ART')`. It may be convenient to group these into e.g. MISC for compatibility with other sources.