### PR TITLE
resolved warning based on suggested method

### DIFF
--- a/skweak/generative.py
+++ b/skweak/generative.py
@@ -157,7 +157,7 @@ class GenerativeModelMixin(AbstractAggregator):
 
         # We also add a constraint that the probability of a state is 
         # zero if no labelling functions "votes" for it
-        votes = np.sum(X[source].dot(self._get_vote_matrix(include_underspec=False)) 
+        votes = sum(X[source].dot(self._get_vote_matrix(include_underspec=False)) 
                        for source in self.emit_counts if source in X)
         logsum= np.where(votes > 0, logsum, -np.inf)
 


### PR DESCRIPTION
Fixes the following warning by replacing `np.sum` with `sum`, as suggested in the `DeprecationWarning`

```
tests/test_aggregation.py: 6179 warnings
  /nr/samba/user/amund/projects/skweak/skweak/generative.py:160: DeprecationWarning: Calling np.sum(generator) is deprecated, and in the future will give a different result. Use np.sum(np.fromiter(generator)) or the python sum builtin instead.
    votes = np.sum(X[source].dot(self._get_vote_matrix(include_underspec=False))
```
